### PR TITLE
Allow users to disable default page tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ ENV['segment'] = {
 
 ```
 
+There is a second option available to disable the default page tracking on the application.didTransition event. If you do not disable this option then tracking events will *by default* be sent to Segment.
+
+```js
+ENV['segment'] = {
+  defaultPageTrack: false
+};
+```
+
 **Version 0.1.x is compatible with ember > 1.13.x**
 
 ## Usage

--- a/addon/instance-initializer.js
+++ b/addon/instance-initializer.js
@@ -3,12 +3,14 @@ export default function instanceInitialize(applicationInstance) {
   var router = applicationInstance.lookup('router:main');
   var segment = applicationInstance.lookup('service:segment');
 
-  router.on('didTransition', function() {
-    segment.trackPageView();
+  if(segment.pageTrackEnabled()) {
+    router.on('didTransition', function() {
+      segment.trackPageView();
 
-    var applicationRoute = applicationInstance.lookup('route:application');
-    if(applicationRoute && typeof applicationRoute.identifyUser === 'function') {
-      applicationRoute.identifyUser();
-    }
-  });
+      var applicationRoute = applicationInstance.lookup('route:application');
+      if(applicationRoute && typeof applicationRoute.identifyUser === 'function') {
+        applicationRoute.identifyUser();
+      }
+    });
+  }
 }

--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -11,6 +11,16 @@ export default Ember.Mixin.create({
     return !!(window.analytics && typeof window.analytics === "object");
   },
 
+  // Default true unless user explicitly sets defaultPageTrack to false
+  pageTrackEnabled: function() {
+    return !this.pageTrackDisabled();
+  },
+
+  pageTrackDisabled: function() {
+    const hasSegmentConfig = (this.config && this.config.segment);
+    return (hasSegmentConfig && this.config.segment.defaultPageTrack === false);
+  },
+
   log: function() {
     if(this.config && this.config.segment && this.config.segment.LOG_EVENT_TRACKING) {
       Ember.Logger.info('[Segment.io] ', arguments);


### PR DESCRIPTION
The default page tracking code is not correct for Ember apps using the hashtag hack (to work with older browsers).

This pull requests changes the onTransition() page tracking code to be opt-in, rather than assuming it is correct for the application using the module.