### PR TITLE
Fix deprecated use of lookupFactory

### DIFF
--- a/addon/initializer.js
+++ b/addon/initializer.js
@@ -1,18 +1,23 @@
 import Ember from 'ember';
 import segmentMixin from './mixin';
 
-export function initialize(container, application) {
-  var config = container.lookupFactory('config:environment');
+function initialize(registry, application) {
   var segment = Ember.Object.extend(segmentMixin);
-
-  application.register('service:segment', segment.extend({ config: config }), { singleton: true });
+  application.register('service:segment', segment, { singleton: true });
   application.inject('route', 'segment', 'service:segment');
   application.inject('router', 'segment', 'service:segment');
   application.inject('controller', 'segment', 'service:segment');
+}
 
+function instanceInitialize(container) {
+  var config = container.lookupFactory('config:environment');
   var router = container.lookup('router:main');
+  var segment = container.lookup('service:segment');
+
+  segment.set('config', config);
+
   router.on('didTransition', function() {
-    container.lookup('service:segment').trackPageView();
+    segment.trackPageView();
 
     var applicationRoute = container.lookup('route:application');
     if(applicationRoute && typeof applicationRoute.identifyUser === 'function') {
@@ -20,3 +25,5 @@ export function initialize(container, application) {
     }
   });
 }
+
+export { initialize, instanceInitialize };

--- a/app/initializers/segmentio.js
+++ b/app/initializers/segmentio.js
@@ -1,6 +1,17 @@
-import { initialize } from 'ember-cli-segment/initializer';
+import Ember from 'ember';
+import { initialize, instanceInitialize } from 'ember-cli-segment/initializer';
+
+function checkVersion(version) {
+  var parts = version.split('.');
+  return (parts[0] > 1 || parts[1] > 10);
+}
 
 export default {
   name: 'segment',
-  initialize: initialize
+  initialize: function(registry, application) {
+    initialize(registry, application);
+    if (!checkVersion(Ember.VERSION)) {
+      instanceInitialize(registry);
+    }
+  }
 };

--- a/app/instance-initializers/segmentio.js
+++ b/app/instance-initializers/segmentio.js
@@ -1,0 +1,8 @@
+import { instanceInitialize } from 'ember-cli-segment/initializer';
+
+export default {
+  name: 'segment',
+  initialize: function(instance) {
+    instanceInitialize(instance.container);
+  }
+};


### PR DESCRIPTION
This is the change based on the documentation.
The deprecation didn't happen until ember 1.11 and is incompatible with
Ember 1.10 so I had to implement a version check for both code paths.

**THIS NEEDS HANDS ON TESTING**

Fixes Issue #8