### PR TITLE
Fix typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   identifyUser: function() {
-    if{this.get('currentUser')) {
+    if (this.get('currentUser')) {
       this.segment.identifyUser(this.get('currentUser.id'), this.get('currentUser')));
     }
   }


### PR DESCRIPTION
`{` should be `(`, also added space after `if` to match space after parenthesis.