### PR TITLE
Add config to enable / disable default identifyUser function

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,19 @@ ENV['segment'] = {
 
 ```
 
-There is a second option available to disable the default page tracking on the application.didTransition event. If you do not disable this option then tracking events will *by default* be sent to Segment.
+There is an option available to disable the default page tracking on the application.didTransition event. If you do not disable this option then tracking events will *by default* be sent to Segment.
 
 ```js
 ENV['segment'] = {
   defaultPageTrack: false
+};
+```
+
+There is an option available to disable the default identify function on the application.didTransition event. If you do not disable this option then identify events will *by default* be sent to Segment.
+
+```js
+ENV['segment'] = {
+  defaultIdentifyUser: false
 };
 ```
 

--- a/addon/instance-initializer.js
+++ b/addon/instance-initializer.js
@@ -6,7 +6,11 @@ export default function instanceInitialize(applicationInstance) {
   if(segment.pageTrackEnabled()) {
     router.on('didTransition', function() {
       segment.trackPageView();
+    });
+  }
 
+  if(segment.identifyUserEnabled()) {
+    router.on('didTransition', function() {
       var applicationRoute = applicationInstance.lookup('route:application');
       if(applicationRoute && typeof applicationRoute.identifyUser === 'function') {
         applicationRoute.identifyUser();

--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -21,6 +21,16 @@ export default Ember.Mixin.create({
     return (hasSegmentConfig && this.config.segment.defaultPageTrack === false);
   },
 
+  // Default true unless user explicitly sets defaultIdentifyUser to false
+  identifyUserEnabled: function() {
+    return !this.identifyUserDisabled();
+  },
+
+  identifyUserDisabled: function() {
+    const hasSegmentConfig = (this.config && this.config.segment);
+    return (hasSegmentConfig && this.config.segment.defaultIdentifyUser === false);
+  },
+
   log: function() {
     if(this.config && this.config.segment && this.config.segment.LOG_EVENT_TRACKING) {
       Ember.Logger.info('[Segment.io] ', arguments);


### PR DESCRIPTION
Since the last commit, if the `defaultPageTrack` flag is set, then it also disables the `identifyUser`. There should be a separate config option for disabling the identify.