### PR TITLE
fix this.config undefined in test

### DIFF
--- a/addon/services/segment.js
+++ b/addon/services/segment.js
@@ -7,7 +7,7 @@ export default Ember.Service.extend({
 
     const isFastBoot = typeof FastBoot !== 'undefined';
 
-    if (!this.hasAnalytics() && this.config.environment !== 'test' && !isFastBoot) {
+    if (!this.hasAnalytics() && (this.config && this.config.environment !== 'test') && !isFastBoot) {
       Ember.Logger.warn('Segment.io is not loaded yet (window.analytics)');
     }
   },


### PR DESCRIPTION
When inject segment service in component, it fails in integration test. See screenshot below:
![image](https://cloud.githubusercontent.com/assets/960322/18122715/0dfa01d2-6fae-11e6-9f3e-fd6b0221a3c1.png)

Need to check `this.config` before accessing environment property.