### PR TITLE
Conditionally load segment and provide ability to lazyload later

### DIFF
--- a/addon/services/segment.js
+++ b/addon/services/segment.js
@@ -64,6 +64,12 @@ export default Ember.Service.extend({
     }
   },
 
+  loadSegment: function(token) {
+    if (this.hasAnalytics()) {
+      window.analytics.load(token);
+    }
+  },
+
   // reset group, user traits and id's
   reset: function() {
     if(this.hasAnalytics()) {

--- a/index.js
+++ b/index.js
@@ -11,11 +11,17 @@ module.exports = {
         return '';
       }
 
-      return '<script type="text/javascript">' +
-                '!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.1.0";' +
-                  'analytics.load("' + config.segment.WRITE_KEY + '");' +
-                '}}();' +
-             '</script>';
+      let segmentScript = '<script type="text/javascript">' +
+                        '!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.1.0";';
+      if (config.segment.WRITE_KEY) {
+        segmentScript = segmentScript + 'analytics.load("' + config.segment.WRITE_KEY + '");'
+
+      }
+
+      segmentScript = segmentScript + '}}();' +
+                    '</script>';
+
+      return segmentScript;
     }
   }
 };


### PR DESCRIPTION
Wanted to submit a quick PR to see if this is functionality you'd be interested in upstream.  If it is, I'll add some tests and clean it up.

Basically if you don't include the WRITE_KEY, it'll load segment but not call the load command.  It also provides a function to load it later on.  Segment automatically stores `track` calls and then replays them when the `load` command is run.

This does NOT seem to be officially support behavior, however, since it's not in the docs - so YMMV.