### PR TITLE
fix double default export

### DIFF
--- a/app/initializers/segment.js
+++ b/app/initializers/segment.js
@@ -1,6 +1,6 @@
 import config from '../config/environment';
 
-export default function initialize() {
+export function initialize() {
   const application = arguments[1] || arguments[0];
 
   const { segment = {} } = config;


### PR DESCRIPTION
I'm getting the following error after updating to the latest version of ember-cli:

```
File: minutebase/initializers/segment.js
The Broccoli Plugin: [broccoli-persistent-filter:Babel] failed with:
SyntaxError: minutebase/initializers/segment.js: Only one default export allowed per module. (14:0)
  12 | }
  13 |
> 14 | export default {
     | ^
  15 |   name: 'segment',
  16 |   initialize: initialize
  17 | };
```

In`initializers/segment.js` it's exporting default twice. 