### PR TITLE
Make master green

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -31,6 +31,7 @@ module.exports = {
     },
     {
       name: 'ember-canary',
+      allowedToFail: true,
       bower: {
         dependencies: {
           'ember': 'components/ember#canary'

--- a/tests/acceptance/router-test.js
+++ b/tests/acceptance/router-test.js
@@ -3,7 +3,6 @@ import startApp from '../helpers/start-app';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-var application;
 window.analytics = {
   page: function() {},
   track: function() {},
@@ -11,6 +10,7 @@ window.analytics = {
   alias: function() {},
 };
 
+var application;
 module('Acceptance: Router', {
   beforeEach: function() {
     application = startApp();
@@ -69,9 +69,8 @@ test('should trigger page and identify when clicking index', function(assert) {
 });
 
 test('should not trigger analytics.identify when visiting /', function(assert) {
-  application.__container__.lookup('route:application').set('identifyUser', null);
   sinon.spy(window.analytics, 'identify');
-  visit('/');
+  visit('/?TEST_NO_IDENTIFY=1');
 
   andThen(function() {
     assert.ok(!window.analytics.identify.called);

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,10 +1,19 @@
 import Ember from 'ember';
 const { inject: { service } } = Ember;
 
+function identifyUser() {
+  this.get('segment').identifyUser(1, { name: 'Josemar Luedke' });
+}
+
 export default Ember.Route.extend({
   segment: service(),
+  identifyUser: null,
 
-  identifyUser: function() {
-    this.get('segment').identifyUser(1, { name: 'Josemar Luedke' });
+  model(params, transition) {
+    if (transition.queryParams.TEST_NO_IDENTIFY) {
+      this.set('identifyUser', null);
+    } else {
+      this.set('identifyUser', identifyUser);
+    }
   }
 });


### PR DESCRIPTION
This fixes failing test for scenarios below Canary.

After merging this I suggest making v1.0.0 official (moving out of beta) as I have another PR ready which upgrades Ember CLI to 2.13 and enables Babel 6 support which should be released as v2.x.