### PR TITLE
Add support for Segment groups

### DIFF
--- a/addon/services/segment.js
+++ b/addon/services/segment.js
@@ -112,6 +112,14 @@ export default Service.extend({
     }
   },
 
+  identifyGroup(groupId, traits, options, callback) {
+    if (this.isEnabled() && this.hasAnalytics()) {
+      window.analytics.group(groupId, traits, options, callback);
+
+      this.log('identifyGroup', traits, options);
+    }
+  },
+
   // reset group, user traits and id's
   reset() {
     if (this.isEnabled() && this.hasAnalytics()) {

--- a/tests/unit/services/segment-test.js
+++ b/tests/unit/services/segment-test.js
@@ -6,6 +6,7 @@ window.analytics = {
   page: function() {},
   track: function() {},
   identify: function() {},
+  group: function() {},
   alias: function() {},
   reset: function() {}
 };
@@ -55,6 +56,21 @@ module('Unit | Service | segment', function(hooks) {
     assert.ok(
       window.analytics.identify.calledWith(
         'userId',
+        'traits',
+        'options',
+        'callback'
+      )
+    );
+  });
+
+  test('calls analytics.group on identifyGroup', function(assert) {
+    let service = this.owner.lookup('service:segment');
+
+    sandbox.spy(window.analytics, 'group');
+    service.identifyGroup('groupId', 'traits', 'options', 'callback');
+    assert.ok(
+      window.analytics.group.calledWith(
+        'groupId',
         'traits',
         'options',
         'callback'


### PR DESCRIPTION
This PR adds an `identifyGroup()` to the Segement service method to provide support for groups.

Segment describes groups in their docs:
> The group API call is how you associate an individual user with a group—be it a company, organization, account, project, team or whatever other crazy name you came up with for the same concept!

You can read more about groups here: https://segment.com/docs/spec/group/

