### PR TITLE
Fix didTransition deprecation on Ember 3.6+

### DIFF
--- a/app/instance-initializers/segment.js
+++ b/app/instance-initializers/segment.js
@@ -1,11 +1,28 @@
+import { VERSION } from '@ember/version';
+
+// Taken from ember-test-helpers
+function hasEmberVersion(major, minor) {
+  const numbers = VERSION.split('-')[0].split('.');
+  const actualMajor = parseInt(numbers[0], 10);
+  const actualMinor = parseInt(numbers[1], 10);
+  return actualMajor > major || (actualMajor === major && actualMinor >= minor);
+}
+
 export function initialize(appInstance) {
   // Support Ember 1.13+
   const owner = appInstance.lookup ? appInstance : appInstance.container;
 
-  const router = owner.lookup('router:main');
+  const routerServicePresent = hasEmberVersion(3, 6);
+
+  const router = owner.lookup(
+    routerServicePresent ? 'service:router' : 'router:main'
+  );
   const segment = owner.lookup('service:segment');
 
-  router.on('didTransition', function() {
+  // Since Ember v3.6 didTransition is deprecated in favour of routeDidChange
+  const eventName = routerServicePresent ? 'routeDidChange' : 'didTransition';
+
+  router.on(eventName, function() {
     const applicationRoute = owner.lookup('route:application');
 
     if (segment && segment.isPageTrackEnabled()) {

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -14,22 +14,27 @@ export default Route.extend({
   identifyUser: null,
 
   model(params, transition) {
-    if (transition.queryParams.TEST_NO_IDENTIFY) {
+    // Ember v3.6+ has public "to" and "from" route info properties
+    const queryParams = transition.to
+      ? transition.to.queryParams
+      : transition.queryParams;
+
+    if (queryParams.TEST_NO_IDENTIFY) {
       this.set('identifyUser', null);
     } else {
       this.set('identifyUser', identifyUser);
     }
 
-    if (transition.queryParams.TEST_DISABLE) {
+    if (queryParams.TEST_DISABLE) {
       this.get('segment').disable();
     }
 
-    if (transition.queryParams.TEST_DISABLE_DEFAULT_TRACKING) {
+    if (queryParams.TEST_DISABLE_DEFAULT_TRACKING) {
       this.get('segment').disableDefaultPageTrack();
       this.get('segment').disableDefaultIdentifyUser();
     }
 
-    if (transition.queryParams.TEST_CUSTOM_TRACK_PAGE) {
+    if (queryParams.TEST_CUSTOM_TRACK_PAGE) {
       this.set('trackPageView', trackPageView);
     } else {
       this.set('trackPageView', null);


### PR DESCRIPTION
Add Ember.VERSION check to use correct service and events available.