### PR TITLE
Enable use of the segment-proxy server with ember-cli-segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ ENV.segment = {
 
 ```js
 ENV.segment = {
-  PROXY_URL: 'segmentproxy.mydomain.com'
+  proxyDomain: 'https://segmentproxy.mydomain.com/'
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Ember CLI Segment
+
 [![Build Status](https://travis-ci.org/josemarluedke/ember-cli-segment.svg?branch=master)](https://travis-ci.org/josemarluedke/ember-cli-segment)
 [![Ember Observer Score](https://emberobserver.com/badges/ember-cli-segment.svg)](https://emberobserver.com/addons/ember-cli-segment)
 
@@ -6,7 +7,7 @@ Ember CLI Segment provides an easy way to integrate your Ember application with 
 
 ## Installation
 
-* `ember install ember-cli-segment`
+- `ember install ember-cli-segment`
 
 **For compatibility with Ember v1.13, use version 2.1.0**
 
@@ -22,7 +23,14 @@ You must provide your segment write key in order to correctly send events to seg
 ENV.segment = {
   WRITE_KEY: 'your_segment_write_key'
 };
+```
 
+### Segment proxy
+
+```js
+ENV.segment = {
+  PROXY_URL: 'segmentproxy.mydomain.com'
+};
 ```
 
 ### Logging
@@ -50,8 +58,7 @@ When disabled, you can call tracking methods of `segment` service but they will 
 enabled later by calling `enable()` method of `segment` service. Segment's script still will be loaded
 on startup. More about the `enable()` method below.
 
-
-There is an option available to disable the default page tracking on the application.didTransition event. If you do not disable this option then tracking events will *by default* be sent to Segment.
+There is an option available to disable the default page tracking on the application.didTransition event. If you do not disable this option then tracking events will _by default_ be sent to Segment.
 
 ```js
 ENV.segment = {
@@ -59,7 +66,7 @@ ENV.segment = {
 };
 ```
 
-There is an option available to disable the default identify function on the application.didTransition event. If you do not disable this option then identify events will *by default* be sent to Segment.
+There is an option available to disable the default identify function on the application.didTransition event. If you do not disable this option then identify events will _by default_ be sent to Segment.
 
 ```js
 ENV.segment = {
@@ -79,7 +86,6 @@ import { inject as service } from '@ember/service';
 export default Component.extend({
   segment: service()
 });
-
 ```
 
 ### Tracking Page Views
@@ -117,7 +123,6 @@ You will probabily need to track other events manually as well. We got you cover
 
 Let's say that you need to track an event when the user submits an form in your router.
 
-
 ```js
 // File: app/routes/posts/new.js
 import Route from '@ember/routing/route';
@@ -132,13 +137,14 @@ export default Route.extend({
     }
   }
 });
-
 ```
 
 `trackEvent` can receive additional properties as well:
 
 ```js
-this.get('segment').trackEvent('Creates a new post', { title: "Creating a Ember CLI application" });
+this.get('segment').trackEvent('Creates a new post', {
+  title: 'Creating a Ember CLI application'
+});
 ```
 
 All the parameters you can provide are: `event`, `properties`, `options`, `callback` in this order.
@@ -163,7 +169,6 @@ export default Route.extend({
 
 You should have in mind that you should make a conditional validation to check if the user is currently logged in. For example:
 
-
 ```js
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
@@ -173,14 +178,16 @@ export default Route.extend({
 
   identifyUser: function() {
     if (this.get('currentUser')) {
-      this.get('segment').identifyUser(this.get('currentUser.id'), this.get('currentUser'));
+      this.get('segment').identifyUser(
+        this.get('currentUser.id'),
+        this.get('currentUser')
+      );
     }
   }
 });
 ```
 
 All the parameters you can provide are: `userId`, `traits`, `options`, `callback` in this order.
-
 
 #### aliasUser
 
@@ -204,17 +211,13 @@ This addon will not break fastBoot, however, it will only execute in the browser
 
 ## Running Tests
 
-* `ember test`
-* `ember test --server`
+- `ember test`
+- `ember test --server`
 
-
-Contributing
-------------------------------------------------------------------------------
+## Contributing
 
 See the [Contributing](CONTRIBUTING.md) guide for details.
 
-
-License
-------------------------------------------------------------------------------
+## License
 
 Licensed under the [MIT license](LICENSE.md).

--- a/index.js
+++ b/index.js
@@ -15,13 +15,20 @@ module.exports = {
         nonceAttr = `nonce="${config.segment.cspNonce}" `;
       }
 
+      const proxyDomain = config.segment.proxyDomain;
+      const segmentDomain = proxyDomain || 'https://cdn.segment.com/';
+
+      if (!/\/$/.test(segmentDomain)) {
+        segmentDomain += '/';
+      }
+
       return (
         '<script ' +
         nonceAttr +
         'type="text/javascript">' +
-        '!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://' +
-        (config.segment.PROXY_URL || 'cdn.segment.com') +
-        '/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";' +
+        '!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="' +
+        segmentDomain +
+        'analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";' +
         'analytics.load("' +
         config.segment.WRITE_KEY +
         '");' +

--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ module.exports = {
         '<script ' +
         nonceAttr +
         'type="text/javascript">' +
-        '!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";' +
+        '!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://' +
+        (config.segment.PROXY_URL || 'cdn.segment.com') +
+        '/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";' +
         'analytics.load("' +
         config.segment.WRITE_KEY +
         '");' +

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = {
       }
 
       const proxyDomain = config.segment.proxyDomain;
-      const segmentDomain = proxyDomain || 'https://cdn.segment.com/';
+      let segmentDomain = proxyDomain || 'https://cdn.segment.com/';
 
       if (!/\/$/.test(segmentDomain)) {
         segmentDomain += '/';


### PR DESCRIPTION
This PR adds a `config.segment.PROXY_URL` config to `ember-cli-segment` for use with [segment-proxy](https://github.com/segmentio/segment-proxy). 