### PR TITLE
Deprecate identifyGroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,27 @@ Additionally we have an `aliasUser` method avaliable on `this.get('segment').ali
 
 All the parameters you can provide are: `userId`, `previousId`, `options`, `callback` in this order.
 
+### Group a user
+
+You can add a user to groups manually.
+
+```js
+// File: app/routes/application.js
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default Route.extend({
+  segment: service(),
+
+  identifyUser: function() {
+    this.get('segment').identifyUser(1, { name: 'Josemar Luedke' });
+    this.get('segment').group(2, {
+      name: 'Josemar Luedke Corp'
+    });
+  }
+});
+```
+
 ### Disabling and enabling at runtime
 
 You can disable/enable segment completely by calling `disable()`/`enable()`. In this case any calls to

--- a/addon/services/segment.js
+++ b/addon/services/segment.js
@@ -1,6 +1,7 @@
 /* globals FastBoot */
 import Service from '@ember/service';
 import { warn } from '@ember/debug';
+import { deprecatingAlias } from '@ember/object/computed';
 
 export default Service.extend({
   _disabled: false,
@@ -119,13 +120,10 @@ export default Service.extend({
     }
   },
 
-  identifyGroup(groupId, traits, options, callback) {
-    if (this.isEnabled() && this.hasAnalytics()) {
-      window.analytics.group(groupId, traits, options, callback);
-
-      this.log('identifyGroup', traits, options);
-    }
-  },
+  identifyGroup: deprecatingAlias('group', {
+    id: 'ember-cli-segment.deprecate-identifyGroup',
+    until: '5.0.0'
+  }),
 
   // reset group, user traits and id's
   reset() {

--- a/addon/services/segment.js
+++ b/addon/services/segment.js
@@ -1,7 +1,7 @@
 /* globals FastBoot */
 import Service from '@ember/service';
 import { warn } from '@ember/debug';
-import { deprecatingAlias } from '@ember/object/computed';
+import { deprecate } from '@ember/application/deprecations';
 
 export default Service.extend({
   _disabled: false,
@@ -120,10 +120,17 @@ export default Service.extend({
     }
   },
 
-  identifyGroup: deprecatingAlias('group', {
-    id: 'ember-cli-segment.deprecate-identifyGroup',
-    until: '5.0.0'
-  }),
+  identifyGroup() {
+    deprecate(
+      'Usage of `identifyGroup` is deprecated, use `group` instead.',
+      false,
+      {
+        id: 'ember-cli-segment.deprecate-identifyGroup',
+        until: '5.0.0'
+      }
+    );
+    return this.group(...arguments);
+  },
 
   // reset group, user traits and id's
   reset() {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ember-load-initializers": "^2.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.4.1",
+    "ember-qunit-assert-helpers": "^0.2.2",
     "ember-resolver": "^5.1.3",
     "ember-sinon": "~4.0.0",
     "ember-source": "~3.11.1",

--- a/tests/unit/services/segment-test.js
+++ b/tests/unit/services/segment-test.js
@@ -76,6 +76,22 @@ module('Unit | Service | segment', function(hooks) {
         'callback'
       )
     );
+    assert.expectDeprecation();
+  });
+
+  test('calls analytics.group on group', function(assert) {
+    let service = this.owner.lookup('service:segment');
+
+    sandbox.spy(window.analytics, 'group');
+    service.group('groupId', 'traits', 'options', 'callback');
+    assert.ok(
+      window.analytics.group.calledWith(
+        'groupId',
+        'traits',
+        'options',
+        'callback'
+      )
+    );
   });
 
   test('calls analytics.identify on aliasUser', function(assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2054,7 +2054,7 @@ broccoli-file-creator@^1.1.1:
     broccoli-plugin "^1.1.0"
     mkdirp "^0.5.1"
 
-broccoli-filter@^1.2.2, broccoli-filter@^1.2.3:
+broccoli-filter@^1.0.1, broccoli-filter@^1.2.2, broccoli-filter@^1.2.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/broccoli-filter/-/broccoli-filter-1.3.0.tgz#71e3a8e32a17f309e12261919c5b1006d6766de6"
   integrity sha512-VXJXw7eBfG82CFxaBDjYmyN7V72D4In2zwLVQJd/h3mBfF3CMdRTsv2L20lmRTtCv1sAHcB+LgMso90e/KYiLw==
@@ -3219,7 +3219,7 @@ ember-cli-babel-plugin-helpers@^1.1.0:
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.0.tgz#de3baedd093163b6c2461f95964888c1676325ac"
   integrity sha512-Zr4my8Xn+CzO0gIuFNXji0eTRml5AxZUTDQz/wsNJ5AJAtyFWCY4QtKdoELNNbiCVGt1lq5yLiwTm4scGKu6xA==
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.16.0, ember-cli-babel@^6.8.1:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.16.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.9.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -3564,6 +3564,14 @@ ember-maybe-import-regenerator@^0.1.6:
     broccoli-merge-trees "^1.0.0"
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
+
+ember-qunit-assert-helpers@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/ember-qunit-assert-helpers/-/ember-qunit-assert-helpers-0.2.2.tgz#6fec8a33fd0d2c3fb6202f849291a309581727a4"
+  integrity sha512-P5eAqD753+p/qEeBi6OGpl2EzRxx8O9dUnr6HgyxU9fqQsSNQkJNGZ+ajbtePI8oMDGm+X7uOnf1+BgQ7eJ7qg==
+  dependencies:
+    broccoli-filter "^1.0.1"
+    ember-cli-babel "^6.9.0"
 
 ember-qunit@^4.4.1:
   version "4.4.1"


### PR DESCRIPTION
Following process documented in:
https://cli.emberjs.com/release/writing-addons/deprecations/