### PR TITLE
Update Segment snippet

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,19 +22,11 @@ module.exports = {
         segmentDomain += '/';
       }
 
-      return (
-        '<script ' +
-        nonceAttr +
-        'type="text/javascript">' +
-        '!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","user","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="' +
-        segmentDomain +
-        'analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";' +
-        'analytics.load("' +
-        config.segment.WRITE_KEY +
-        '");' +
-        '}}();' +
-        '</script>'
-      );
+      return `<script ${nonceAttr} type="text/javascript">
+          !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="${segmentDomain}analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="${config.segment.WRITE_KEY}";analytics.SNIPPET_VERSION="4.13.2";
+          analytics.load("${config.segment.WRITE_KEY}");
+          }}();
+        </script>`;
     }
   }
 };


### PR DESCRIPTION
Hello!

Segment has announced they were about to roll out their v2. In some cases, it seems upgrading the init snippet is a requirement, so I made up a PR to do so :)

Here are some links:
- Documentation https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/upgrade-to-ajs2/ (`[...] you should update the AJS snippet to the latest version (4.13.2 or higher) before you toggle on Analytics.js 2.0.`)
- Snippet has been taken from https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/quickstart/

Let me know if there is anything else I could do to help with this!
Thank you!