### PR TITLE
Avoid config usage at build time

### DIFF
--- a/app/initializers/segment.js
+++ b/app/initializers/segment.js
@@ -7,6 +7,15 @@ export function initialize() {
   const { environment = 'development' } = config;
   const segmentConfig = { segment, environment };
 
+  let segmentDomain = config.segment.proxyDomain || 'https://cdn.segment.com/';
+  if (!/\/$/.test(segmentDomain)) {
+    segmentDomain += '/';
+  }
+
+  window['__ember-cli-segment__'] = {};
+  window['__ember-cli-segment__'].WRITE_KEY = config.segment.WRITE_KEY;
+  window['__ember-cli-segment__'].host = segmentDomain;
+
   application.register('config:segment', segmentConfig, { instantiate: false });
   application.inject('service:segment', 'config', 'config:segment');
 }

--- a/index.js
+++ b/index.js
@@ -5,27 +5,18 @@ module.exports = {
 
   contentFor: function(type, config) {
     if (type === 'body-footer') {
-      if (!config.segment || !config.segment.WRITE_KEY) {
-        return '';
-      }
-
       let nonceAttr = '';
 
-      if (config.segment.cspNonce) {
+      if (config.segment && config.segment.cspNonce) {
         nonceAttr = `nonce="${config.segment.cspNonce}" `;
       }
 
-      const proxyDomain = config.segment.proxyDomain;
-      let segmentDomain = proxyDomain || 'https://cdn.segment.com/';
-
-      if (!/\/$/.test(segmentDomain)) {
-        segmentDomain += '/';
-      }
-
       return `<script ${nonceAttr} type="text/javascript">
-          !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="${segmentDomain}analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="${config.segment.WRITE_KEY}";analytics.SNIPPET_VERSION="4.13.2";
-          analytics.load("${config.segment.WRITE_KEY}");
-          }}();
+          if (window['ember-cli-segment'] && window['ember-cli-segment'].WRITE_KEY) {
+            !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src=window['ember-cli-segment'].host + "analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey=window['ember-cli-segment'].WRITE_KEY;analytics.SNIPPET_VERSION="4.13.2";
+            analytics.load(window['ember-cli-segment'].WRITE_KEY);
+            }}();
+          }
         </script>`;
     }
   }


### PR DESCRIPTION
As I understand Ember configuration files:
- `ember-cli-build.js` is for build time configuration
- `config/environment` is for run time configuration

My goal is to drive segment config at runtime to be able to reuse build artifact across multiple environments.

This first attempt use `window` variable to communicate the Ember config to the Segment snippet